### PR TITLE
fix(event): update for GA4

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,5 +1,5 @@
 export {};
 
 declare global {
-  interface Window { ga: any; }
+  interface Window { gtag: any; }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,13 +16,10 @@ export default function Home(): JSX.Element {
   const { hero, clients } = siteConfig.customFields as CustomFields;
 
   const tiggerEvent = (idx: number): void => {
-    if (typeof window.ga === 'function') {
-      window.ga('send', {
-        hitType: 'event',
-        eventCategory: 'developers',
-        eventAction: 'selected',
-        eventLabel: 'client',
-        eventValue: clients[idx].title,
+    if (typeof window.gtag === 'function') {
+      window.gtag('event', 'select_content', {
+        content_type: 'Developer Client SDK',
+        content_id: clients[idx].title,
       });
     }
   }


### PR DESCRIPTION
GA4 changes the way events are sent to the Google Analytics platform. This commit fixes the tracking event when somebody selects a client SDK on the homepage.

https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#select_content